### PR TITLE
BACK: Corregir caché AEMET y timeout de primera llamada HTTP

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,7 +20,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
         },
       ],
     }),
-    CacheModule.register({ isGlobal: true, ttl: 3600, max: 200 }),
+    CacheModule.register({ isGlobal: true, ttl: 3600 * 1000, max: 200 }),
     WeatherModule,
     CitiesModule,
   ],

--- a/backend/src/modules/weather/controllers/weather.controller.ts
+++ b/backend/src/modules/weather/controllers/weather.controller.ts
@@ -17,9 +17,18 @@ export class WeatherController {
 
   @Post()
   async fetchWeatherData(@Body() weatherRequest: WeatherRequest) {
-    const { townCode, provinceCode } = weatherRequest;
-    const weather = await this.aemetService.getWeather(townCode, provinceCode);
-    return { status: 'ok', data: weather };
+    try {
+      const { townCode, provinceCode } = weatherRequest;
+      const weather = await this.aemetService.getWeather(townCode, provinceCode);
+      return { status: 'ok', data: weather };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new HttpException(
+        { status: 'error', message },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
   }
 
   @Get(':code')
@@ -36,8 +45,10 @@ export class WeatherController {
       );
       return { status: 'ok', data: weather };
     } catch (error) {
+      if (error instanceof HttpException) throw error;
+      const message = error instanceof Error ? error.message : String(error);
       throw new HttpException(
-        { status: 'error', message: error.message },
+        { status: 'error', message },
         HttpStatus.BAD_GATEWAY,
       );
     }

--- a/backend/src/modules/weather/controllers/weather.controller.ts
+++ b/backend/src/modules/weather/controllers/weather.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { WeatherRequest } from '../models/weather-request';
 import { AemetService } from '../services/aemet.service';
+import { AemetError } from '../errors/aemet.error';
 import { CacheTTL } from '@nestjs/cache-manager';
 
 @Controller('weather')
@@ -19,15 +20,19 @@ export class WeatherController {
   async fetchWeatherData(@Body() weatherRequest: WeatherRequest) {
     try {
       const { townCode, provinceCode } = weatherRequest;
-      const weather = await this.aemetService.getWeather(townCode, provinceCode);
+      const weather = await this.aemetService.getWeather(
+        townCode,
+        provinceCode,
+      );
       return { status: 'ok', data: weather };
     } catch (error) {
       if (error instanceof HttpException) throw error;
       const message = error instanceof Error ? error.message : String(error);
-      throw new HttpException(
-        { status: 'error', message },
-        HttpStatus.BAD_GATEWAY,
-      );
+      const httpStatus =
+        error instanceof AemetError
+          ? HttpStatus.BAD_GATEWAY
+          : HttpStatus.INTERNAL_SERVER_ERROR;
+      throw new HttpException({ status: 'error', message }, httpStatus);
     }
   }
 
@@ -47,10 +52,11 @@ export class WeatherController {
     } catch (error) {
       if (error instanceof HttpException) throw error;
       const message = error instanceof Error ? error.message : String(error);
-      throw new HttpException(
-        { status: 'error', message },
-        HttpStatus.BAD_GATEWAY,
-      );
+      const httpStatus =
+        error instanceof AemetError
+          ? HttpStatus.BAD_GATEWAY
+          : HttpStatus.INTERNAL_SERVER_ERROR;
+      throw new HttpException({ status: 'error', message }, httpStatus);
     }
   }
 }

--- a/backend/src/modules/weather/controllers/weather.controller.ts
+++ b/backend/src/modules/weather/controllers/weather.controller.ts
@@ -2,35 +2,28 @@ import {
   Body,
   Controller,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   Post,
-  UseInterceptors,
 } from '@nestjs/common';
 import { WeatherRequest } from '../models/weather-request';
 import { AemetService } from '../services/aemet.service';
-import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { CacheTTL } from '@nestjs/cache-manager';
 
 @Controller('weather')
-@UseInterceptors(CacheInterceptor)
 export class WeatherController {
   constructor(private readonly aemetService: AemetService) {}
 
   @Post()
   async fetchWeatherData(@Body() weatherRequest: WeatherRequest) {
-    try {
-      const { townCode, provinceCode } = weatherRequest;
-      const weather = await this.aemetService.getWeather(
-        townCode,
-        provinceCode,
-      );
-      return { status: 'ok', data: weather };
-    } catch (error) {
-      return { status: 'error', message: error.message };
-    }
+    const { townCode, provinceCode } = weatherRequest;
+    const weather = await this.aemetService.getWeather(townCode, provinceCode);
+    return { status: 'ok', data: weather };
   }
 
   @Get(':code')
-  @CacheTTL(3600)
+  @CacheTTL(3600 * 1000)
   async getByWeatherDataParams(@Param() params: { code: string }) {
     try {
       const { code } = params;
@@ -43,7 +36,10 @@ export class WeatherController {
       );
       return { status: 'ok', data: weather };
     } catch (error) {
-      return { status: 'error', message: error.message };
+      throw new HttpException(
+        { status: 'error', message: error.message },
+        HttpStatus.BAD_GATEWAY,
+      );
     }
   }
 }

--- a/backend/src/modules/weather/errors/aemet.error.ts
+++ b/backend/src/modules/weather/errors/aemet.error.ts
@@ -2,5 +2,6 @@ export class AemetError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AemetError';
+    Object.setPrototypeOf(this, AemetError.prototype);
   }
 }

--- a/backend/src/modules/weather/errors/aemet.error.ts
+++ b/backend/src/modules/weather/errors/aemet.error.ts
@@ -1,0 +1,6 @@
+export class AemetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AemetError';
+  }
+}

--- a/backend/src/modules/weather/services/aemet.service.ts
+++ b/backend/src/modules/weather/services/aemet.service.ts
@@ -18,9 +18,9 @@ export class AemetService {
             headers: {
               api_key: process.env.AEMET_API_KEY ?? '',
               Accept: 'application/json',
-              timeout: 10000,
-              maxRedirects: 5,
             },
+            timeout: 10000,
+            maxRedirects: 5,
           },
         ),
       );

--- a/backend/src/modules/weather/services/aemet.service.ts
+++ b/backend/src/modules/weather/services/aemet.service.ts
@@ -2,6 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
 import { AemetData, Dato, Dia } from '../models/aemet-data';
+import { AemetError } from '../errors/aemet.error';
 import { SimplifiedData } from '../models/simplified-data';
 import { GachasLevel } from '../enums/gachas-level.enum';
 
@@ -46,7 +47,7 @@ export class AemetService {
         error?.response?.data ||
         error?.message ||
         'Error desconocido';
-      throw new Error(`AEMET request failed: ${msg}`);
+      throw new AemetError(`AEMET request failed: ${msg}`);
     }
   }
 


### PR DESCRIPTION
- TTL del caché corregido de 3.6s a 1h (cache-manager v7 usa ms)
- Errores de AEMET lanzan HttpException 502 para evitar cachear respuestas de error
- timeout/maxRedirects movidos fuera de headers en primera llamada Axios
- Eliminado CacheInterceptor duplicado en WeatherController